### PR TITLE
Change config type to COMMON

### DIFF
--- a/src/main/java/net/jcm/vsch/config/VSCHConfig.java
+++ b/src/main/java/net/jcm/vsch/config/VSCHConfig.java
@@ -59,6 +59,6 @@ public class VSCHConfig {
 		SPEC = BUILDER.build();
 	}
 	public static void register(ModLoadingContext context){
-		context.registerConfig(ModConfig.Type.SERVER, VSCHConfig.SPEC, "vsch-config.toml");
+		context.registerConfig(ModConfig.Type.COMMON, VSCHConfig.SPEC, "vsch-config.toml");
 	}
 }


### PR DESCRIPTION
Right now the config type is SERVER, which makes the game not generate a config file if you launch the client. By changing it to COMMON, the config file generates and it's easier to configure the game if playing single player.