### PR TITLE
Revert "Change config type to COMMON"

### DIFF
--- a/src/main/java/net/jcm/vsch/config/VSCHConfig.java
+++ b/src/main/java/net/jcm/vsch/config/VSCHConfig.java
@@ -56,6 +56,6 @@ public class VSCHConfig {
 		SPEC = BUILDER.build();
 	}
 	public static void register(ModLoadingContext context){
-		context.registerConfig(ModConfig.Type.COMMON, VSCHConfig.SPEC, "vsch-config.toml");
+		context.registerConfig(ModConfig.Type.SERVER, VSCHConfig.SPEC, "vsch-config.toml");
 	}
 }


### PR DESCRIPTION
Reverts jcm236/Starlance#15

Config type should be `SERVER`, so each single player world will generate its own config in the `serverconfig` folder.