### PR TITLE
make thruster work without ship

### DIFF
--- a/src/main/java/net/jcm/vsch/blocks/custom/template/AbstractThrusterBlock.java
+++ b/src/main/java/net/jcm/vsch/blocks/custom/template/AbstractThrusterBlock.java
@@ -122,18 +122,6 @@ public abstract class AbstractThrusterBlock<T extends AbstractThrusterBlockEntit
 			return InteractionResult.PASS;
 		}
 
-		// Get the force handler
-		VSCHForceInducedShips ships = VSCHForceInducedShips.get(level, pos);
-
-		// If a force handler exists (might not if we aren't on a VS ship)
-		if (ships == null) {
-			// Not on a ship
-			player.displayClientMessage(Component.translatable("vsch.error.thruster_not_on_ship").withStyle(
-				ChatFormatting.RED
-			), true);
-			return InteractionResult.FAIL;
-		}
-
 		// Get thruster
 		AbstractThrusterBlockEntity thruster = (AbstractThrusterBlockEntity) level.getBlockEntity(pos);
 		if (thruster == null) {

--- a/src/main/java/net/jcm/vsch/blocks/thruster/AbstractThrusterBlockEntity.java
+++ b/src/main/java/net/jcm/vsch/blocks/thruster/AbstractThrusterBlockEntity.java
@@ -188,11 +188,7 @@ public abstract class AbstractThrusterBlockEntity extends BlockEntity implements
 			this.resolveBrain();
 		}
 
-		Ship ship = VSGameUtilsKt.getShipManagingPos(level, pos);
-		// If we aren't on a ship, then we skip
-		if (ship == null) {
-			return;
-		}
+		final Ship ship = VSGameUtilsKt.getShipManagingPos(level, pos);
 
 		// If we are unpowered, do no particles
 		if (this.getCurrentPower() == 0.0) {
@@ -200,13 +196,19 @@ public abstract class AbstractThrusterBlockEntity extends BlockEntity implements
 		}
 
 		// BlockPos is always at the corner, getCenter gives us a Vec3 thats centered YAY
-		Vec3 center = pos.getCenter();
+		final Vec3 center = pos.getCenter();
 		// Transform that shipyard pos into a world pos
-		Vector3d worldPos = ship.getTransform().getShipToWorld().transformPosition(new Vector3d(center.x, center.y, center.z));
+		final Vector3d worldPos = new Vector3d(center.x, center.y, center.z);
+		if (ship != null) {
+			ship.getTransform().getShipToWorld().transformPosition(worldPos);
+		}
 
 		// Get blockstate direction, NORTH, SOUTH, UP, DOWN, etc
-		Direction dir = state.getValue(DirectionalBlock.FACING);
-		Vector3d direction = ship.getTransform().getShipToWorldRotation().transform(new Vector3d(dir.getStepX(), dir.getStepY(), dir.getStepZ()));
+		final Direction dir = state.getValue(DirectionalBlock.FACING);
+		final Vector3d direction = new Vector3d(dir.getStepX(), dir.getStepY(), dir.getStepZ());
+		if (ship != null) {
+			ship.getTransform().getShipToWorldRotation().transform(direction);
+		}
 
 		spawnParticles(worldPos, direction);
 	}

--- a/src/main/resources/assets/vsch/lang/en_us.json
+++ b/src/main/resources/assets/vsch/lang/en_us.json
@@ -5,7 +5,6 @@
 	"vsch.global": " §6GLOBAL",
 	"vsch.position": " §ePOSITION",
 	"vsch.error.thruster_modes_disabled": "Thruster mode toggling is disabled!",
-	"vsch.error.thruster_not_on_ship": "Thruster not on a ship",
 	"block.vsch.thruster_block": "Thruster",
 	"block.vsch.drag_inducer_block": "Drag inducer",
 	"block.vsch.air_thruster_block": "Air thruster",


### PR DESCRIPTION
Thrusters should be able to set mode when not on ship so player does not have to find all thrusters after they assembles the ship.

Thrusters should also be able to power when not on ship for deco.

