### PR TITLE
Add our own fluids

### DIFF
--- a/src/main/java/net/jcm/vsch/VSCHMod.java
+++ b/src/main/java/net/jcm/vsch/VSCHMod.java
@@ -10,6 +10,8 @@ import net.jcm.vsch.compat.create.ponder.VSCHPonderTags;
 import net.jcm.vsch.config.VSCHConfig;
 import net.jcm.vsch.entity.VSCHEntities;
 import net.jcm.vsch.event.GravityInducer;
+import net.jcm.vsch.fluids.VSCHFluidTypes;
+import net.jcm.vsch.fluids.VSCHFluids;
 import net.jcm.vsch.items.VSCHItems;
 import net.minecraftforge.client.event.EntityRenderersEvent;
 import net.minecraftforge.common.MinecraftForge;
@@ -35,6 +37,10 @@ public class VSCHMod {
 		VSCHTab.register(modBus);
 		VSCHEntities.register(modBus);
 		VSCHTags.register();
+
+		VSCHFluidTypes.register(modBus);
+		VSCHFluids.register(modBus);
+
 		// Register commands (I took this code from another one of my mods, can't be bothered to make it consistent with the rest of this)
 		MinecraftForge.EVENT_BUS.register(ModCommands.class);
 

--- a/src/main/java/net/jcm/vsch/config/VSCHConfig.java
+++ b/src/main/java/net/jcm/vsch/config/VSCHConfig.java
@@ -118,7 +118,7 @@ public class VSCHConfig {
 
 	private static String getDefaultThrusterFuelConsumeRates() {
 		Map<String, Integer> rates = new HashMap<>();
-		// rates.put("minecraft:lava", 32);
+		rates.put("vsch:hydrogen", 32);
 		return GSON.toJson(rates);
 	}
 

--- a/src/main/java/net/jcm/vsch/fluids/BasicGasFluidType.java
+++ b/src/main/java/net/jcm/vsch/fluids/BasicGasFluidType.java
@@ -1,0 +1,60 @@
+package net.jcm.vsch.fluids;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.client.extensions.common.IClientFluidTypeExtensions;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.FluidType;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Consumer;
+
+
+public class BasicGasFluidType extends FluidType {
+    private final ResourceLocation stillTexture;
+    private final int tintColor;
+
+    public BasicGasFluidType(final ResourceLocation stillTexture,
+                             final int tintColor, final Properties properties) {
+        super(properties);
+        this.stillTexture = stillTexture;
+        this.tintColor = tintColor;
+    }
+
+    public ResourceLocation getStillTexture() {
+        return stillTexture;
+    }
+
+    public int getTintColor() {
+        return tintColor;
+    }
+
+    @Override
+    public void initializeClient(Consumer<IClientFluidTypeExtensions> consumer) {
+        consumer.accept(new IClientFluidTypeExtensions() {
+            @Override
+            public ResourceLocation getStillTexture() {
+                return stillTexture;
+            }
+
+            @Override
+            public int getTintColor() {
+                return tintColor;
+            }
+        });
+    }
+
+    @Override
+    public boolean isVaporizedOnPlacement(Level level, BlockPos pos, FluidStack stack)
+    {
+        return true;
+    }
+
+    @Override
+    public void onVaporize(@Nullable Player player, Level level, BlockPos pos, FluidStack stack) {
+        // Otherwise it will vaporize like water
+        // we can add particles and other fancy stuff here later
+    }
+}

--- a/src/main/java/net/jcm/vsch/fluids/VSCHFluidTypes.java
+++ b/src/main/java/net/jcm/vsch/fluids/VSCHFluidTypes.java
@@ -1,0 +1,35 @@
+package net.jcm.vsch.fluids;
+
+import net.jcm.vsch.VSCHMod;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fluids.FluidType;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+
+public class VSCHFluidTypes {
+    public static final ResourceLocation WATER_STILL_RL = new ResourceLocation("block/water_still");
+
+    public static final DeferredRegister<FluidType> FLUID_TYPES =
+            DeferredRegister.create(ForgeRegistries.Keys.FLUID_TYPES,VSCHMod.MODID);
+
+    public static final RegistryObject<FluidType> BASIC_GAS_FLUID_TYPE = register("basic_gas",
+            FluidType.Properties.create()
+    );
+
+
+
+    private static RegistryObject<FluidType> register(String name, FluidType.Properties properties) {
+        return FLUID_TYPES.register(name, () -> new BasicGasFluidType(
+                WATER_STILL_RL, // Used as the texture in JEI and stuff, important
+                0xFFFFFFFF, //TODO: Make this more transparent if possible
+                properties
+            )
+        );
+    }
+
+    public static void register(IEventBus eventBus) {
+        FLUID_TYPES.register(eventBus);
+    }
+}

--- a/src/main/java/net/jcm/vsch/fluids/VSCHFluids.java
+++ b/src/main/java/net/jcm/vsch/fluids/VSCHFluids.java
@@ -1,0 +1,38 @@
+package net.jcm.vsch.fluids;
+
+import net.jcm.vsch.VSCHMod;
+import net.jcm.vsch.items.VSCHItems;
+import net.minecraft.world.level.material.FlowingFluid;
+import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.level.material.Fluids;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fluids.ForgeFlowingFluid;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+
+public class VSCHFluids {
+
+    public static final DeferredRegister<Fluid> FLUIDS = DeferredRegister.create(ForgeRegistries.FLUIDS, VSCHMod.MODID);
+
+    // For some reason JEI uses the fluid type's registry name to display on the fluid itself in JEI
+    // So we might want to change this around later, but for now the buckets will cover up that weirdness
+    public static final RegistryObject<FlowingFluid> HYDROGEN = FLUIDS.register("hydrogen",
+            () -> new ForgeFlowingFluid.Source(VSCHFluids.HYDROGEN_PROPERTIES));
+
+    public static final RegistryObject<FlowingFluid> OXYGEN = FLUIDS.register("oxygen",
+            () -> new ForgeFlowingFluid.Source(VSCHFluids.OXYGEN_PROPERTIES));
+
+    public static final ForgeFlowingFluid.Properties HYDROGEN_PROPERTIES = new ForgeFlowingFluid.Properties(
+            VSCHFluidTypes.BASIC_GAS_FLUID_TYPE, HYDROGEN, Fluids.FLOWING_WATER.builtInRegistryHolder())
+            .bucket(VSCHItems.HYDROGEN_BUCKET);
+
+    public static final ForgeFlowingFluid.Properties OXYGEN_PROPERTIES = new ForgeFlowingFluid.Properties(
+            VSCHFluidTypes.BASIC_GAS_FLUID_TYPE, OXYGEN, Fluids.FLOWING_WATER.builtInRegistryHolder())
+            .bucket(VSCHItems.OXYGEN_BUCKET);
+
+
+    public static void register(IEventBus eventBus) {
+        FLUIDS.register(eventBus);
+    }
+}

--- a/src/main/java/net/jcm/vsch/items/VSCHItems.java
+++ b/src/main/java/net/jcm/vsch/items/VSCHItems.java
@@ -1,12 +1,14 @@
 package net.jcm.vsch.items;
 
+import net.jcm.vsch.fluids.VSCHFluids;
 import net.jcm.vsch.items.custom.MagnetBootItem;
 import net.minecraft.world.item.ArmorMaterials;
+import net.minecraft.world.item.BucketItem;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.Items;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.registries.DeferredRegister;
 import net.jcm.vsch.VSCHMod;
-import net.jcm.vsch.VSCHTab;
 import net.minecraft.world.item.ArmorItem.Type;
 import net.jcm.vsch.items.custom.WrenchItem;
 import net.minecraftforge.registries.ForgeRegistries;
@@ -24,6 +26,19 @@ public class VSCHItems {
 		"magnet_boot",
 		() -> new MagnetBootItem(ArmorMaterials.IRON, Type.BOOTS, new Item.Properties())
 	);
+
+	public static final RegistryObject<Item> HYDROGEN_BUCKET = ITEMS.register(
+			"hydrogen_bucket",
+			() -> new BucketItem(VSCHFluids.HYDROGEN,
+					new Item.Properties().craftRemainder(Items.BUCKET).stacksTo(1))
+	);
+
+	public static final RegistryObject<Item> OXYGEN_BUCKET = ITEMS.register(
+			"oxygen_bucket",
+			() -> new BucketItem(VSCHFluids.OXYGEN,
+					new Item.Properties().craftRemainder(Items.BUCKET).stacksTo(1))
+	);
+
 
 	public static void register(IEventBus eventBus) {
 		ITEMS.register(eventBus);


### PR DESCRIPTION
This PR will aim to:
- add fluid registry
- Register hydrogen and oxygen as fluids
- Add “compat-inator” that (using JSON recipes) can convert other mods fluids to ours (and vice versa?)
- Add electrolyser for water -> hydrogen + oxygen (JEI and JSON compat too)
- Add hydrogen engine (nice source of FE for now while CH hasn't finished that)
- Add fluid tank I guess? Needs to be unique somehow, I don't like having such a similar feature to so many other mods